### PR TITLE
All codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "mocha": "^2.3.4",
     "eslint-config-vgno": "^5.0.0",
     "eslint": "^1.8.0"
+  },
+  "dependencies": {
+    "colors": "^1.1.2"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,9 +1,14 @@
 'use strict';
 
 var httpStatus = require('./index');
+var codes = require('./status-codes');
 
+// Print all status codes if none are provided
 if (!process.argv[2]) {
-    return false;
+    Object.keys(codes).forEach(function(code) {
+        printCode(code, codes[code].message, codes[code].description);
+    });
+    return;
 }
 
 httpStatus(process.argv[2], function(err, msg, desc) {
@@ -11,6 +16,10 @@ httpStatus(process.argv[2], function(err, msg, desc) {
         console.log(err);
     }
 
-    console.log('%d - %s', process.argv[2], msg);
-    console.log(desc);
+    printCode(process.argv[2], msg, desc);
 });
+
+function printCode(code, msg, desc) {
+    console.log('%d - %s', code, msg);
+    console.log(desc);
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('colors');
 var httpStatus = require('./index');
 var codes = require('./status-codes');
 
@@ -13,13 +14,21 @@ if (!process.argv[2]) {
 
 httpStatus(process.argv[2], function(err, msg, desc) {
     if (err) {
-        console.log(err);
+        console.log(err.red);
+        return;
     }
 
     printCode(process.argv[2], msg, desc);
 });
 
 function printCode(code, msg, desc) {
-    console.log('%d - %s', code, msg);
-    console.log(desc);
+    if(code < 400) {
+        code = code.green
+    }else if(code < 500) {
+        code = code.yellow
+    }else {
+        code = code.red
+    }
+    console.log('%s - %s', code, msg.gray);
+    console.log('  %s', desc);
 }


### PR DESCRIPTION
Tweaking the cli behavior slightly when no status code is provided by having it output all of the status codes, hopefully that's ok by you.  I often want to see all of them, or a large section, so this seemed useful.

I also took the liberty to pull in `colors` and add some color coding the the output.  Let me know if you'd prefer not to have that, or if you would like me to change anything there.
## 100-308 - Green

![image](https://cloud.githubusercontent.com/assets/367275/12225645/2ee7a5ec-b7cc-11e5-9461-fe2a35362174.png)
## 400-451 - Yellow

![image](https://cloud.githubusercontent.com/assets/367275/12225648/395b83ae-b7cc-11e5-8d72-52f45fb0e7c4.png)
## 500+ - Red

![image](https://cloud.githubusercontent.com/assets/367275/12225652/4b00bffc-b7cc-11e5-8bf5-04b34fbb5e93.png)
## Single code output is also color formatted with this PR

![image](https://cloud.githubusercontent.com/assets/367275/12225660/71749082-b7cc-11e5-8201-2787ca0cb3bc.png)
